### PR TITLE
added flexibility to http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ upwork/__init__.py.back
 python_upwork.egg-info
 reference-docs
 _gh-pages
+.idea

--- a/upwork/ca_certs_locater.py
+++ b/upwork/ca_certs_locater.py
@@ -5,6 +5,8 @@ LINUX_PATH = '/etc/ssl/certs/ca-certificates.crt'
 # openssl installed using `brew install openssl`
 OSX_PATH = '/usr/local/etc/openssl/cert.pem'
 
+CUSTOM_SSL_CERT_PATH = os.getenv('UPWORK_SSL_CERT', '')
+
 
 def get():
     """Return a path to a certificate authority file.
@@ -17,6 +19,9 @@ def get():
 
     if os.path.exists(OSX_PATH):
         return OSX_PATH
+
+    if CUSTOM_SSL_CERT_PATH and os.path.exists(CUSTOM_SSL_CERT_PATH):
+        return CUSTOM_SSL_CERT_PATH
 
     # Fall back to the httplib2 default behavior by raising an
     # ImportError if we have not found the file.


### PR DESCRIPTION
changes allow for some flexibility in setting the http client (if a company uses non-standard paths for SSL or uses proxies)

by putting the import for `get` in `upwork/ca_certs_locater.py` allows (indirectly at least) for windows support